### PR TITLE
Fix soft stops and add option for hard stops

### DIFF
--- a/chipdrive.py
+++ b/chipdrive.py
@@ -234,7 +234,20 @@ class tmc5130(trinamicDriver.TrinamicDriver):
         self.enableOutput(True)
         self.readWriteMultiple(regupdates,'W')
 
-    def stop(self):
+    def stop_here(self):
+        """
+        Terminates motion softly by setting the current position as the new stop target.  Waits for positioning to
+        complete.
+
+        Driver will ramp down to zero velocity and then position the rotor back to the new stop target.
+        """
+        self.writeInt('XTARGET', self.readInt('XACTUAL'))
+        self.writeInt('VMAX', round(self.RPMtoVREG(self['settings/maxrpm'].getCurrent())))
+        self.writeInt('RAMPMODE', tmc5130regs.RAMPmode.POSITION)
+        self.waitStop(ticktime=.1)
+        self.enableOutput(False)
+
+    def soft_stop(self):
         """
         Terminates motion using a soft stop. Waits for ramp down to complete.
 

--- a/trinamicDriver.py
+++ b/trinamicDriver.py
@@ -581,6 +581,16 @@ class triMixed(triRegister):
         zap=self.curval & ~self.flagmask
         self.curval = zap | flags.value
 
+    def toggleFlag(self, flag):
+        """
+        Toggles the flag bit
+        """
+        assert not self.flagmask is None
+        flags = self.flagClass(self.curval & self.flagmask)
+        flags ^= flag
+        zap = self.curval & ~self.flagmask
+        self.curval = zap | flags.value
+
     def loadBytes(self, ba):
         self.curval=self.unpackBytes(ba)
 


### PR DESCRIPTION
Calling `stop()` did not work as expected for me.  It caused the motor to:

- decelerate to a complete stop,
- accelerate in the reverse direction, and then 
- come to a final stop

---

It seems like `waitStop()` was not polling frequently enough to catch the moment at which the motor velocity reached zero.  When the velocity reached zero, the driver would notice the difference between `XACTUAL` and `XTARGET` and drive backwards to compensate.

One way to fix this would be to poll more frequently, i.e. reduce the `ticktime`.  It must be reduced to less than `TZEROWAIT`, so we can catch the moment when velocity is zero.  However, `TZEROWAIT` cannot be always initialized to a safe value.  (It is derived from the driver's clock frequency and would vary for different circuits).

I've changed `stop()` to use one of the other methods described in the datasheet (see 'Early Ramp Termination').  It no longer depends on `TZEROWAIT` or even directly on `ticktime`.

---

I've also added the option to perform a `hard_stop()` which will cause the motor to halt without ramping down (per the same section in the datasheet).

Let me know what you think.  Thanks!